### PR TITLE
Pass additional classes into <picture> element

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following image object is expected by the component -
 {
 	url: 'someurl', //This will be passed into the image service
 	alt: 'your alt text',
+	class: 'any-bespoke-classes you-want-to-add', //Optional added to <picture> element along with n-image
 	srcset: {
 		fallback: 500, //Optional pixel width for fallback image.
 		default: 200, //The default image size. This will be shown if non of the breakpoint sizes are matched or some haven't been specified

--- a/templates/image.html
+++ b/templates/image.html
@@ -1,4 +1,4 @@
-<picture class="n-image">
+<picture class="{{#if image.class}}{{image.class}} {{/if}}n-image">
 	<!--[if IE 9]><video style="display: none;"><![endif]-->
 	{{#if image.srcset.xl}}
 		<source srcset="{{#resize image.srcset.xl}}{{image.url}}{{/resize}}" media="(min-width: 1210px)">


### PR DESCRIPTION
@tom-parker 

Thought the ability to pass in additional classes to the picture element could prove useful? 
My use case was that I was trying to place the image, but didn't want to create an extra div as placeholder or target n-image with CSS recognising it may be quite common.

Any thoughts?