### PR TITLE
Dont encode url

### DIFF
--- a/templates/image.html
+++ b/templates/image.html
@@ -1,23 +1,23 @@
 <picture class="{{#if image.class}}{{image.class}} {{/if}}n-image">
 	<!--[if IE 9]><video style="display: none;"><![endif]-->
 	{{#if image.srcset.xl}}
-		<source srcset="{{#resize image.srcset.xl}}{{image.url}}{{/resize}}" media="(min-width: 1210px)">
+		<source srcset="{{#resize image.srcset.xl}}{{{image.url}}}{{/resize}}" media="(min-width: 1210px)">
 	{{/if}}
 	{{#if image.srcset.l}}
-		<source srcset="{{#resize image.srcset.l}}{{image.url}}{{/resize}}" media="(min-width: 970px)">
+		<source srcset="{{#resize image.srcset.l}}{{{image.url}}}{{/resize}}" media="(min-width: 970px)">
 	{{/if}}
 	{{#if image.srcset.m}}
-		<source srcset="{{#resize image.srcset.m}}{{image.url}}{{/resize}}" media="(min-width: 730px)">
+		<source srcset="{{#resize image.srcset.m}}{{{image.url}}}{{/resize}}" media="(min-width: 730px)">
 	{{/if}}
 	{{#if image.srcset.s}}
-		<source srcset="{{#resize image.srcset.s}}{{image.url}}{{/resize}}" media="(min-width: 490px)">
+		<source srcset="{{#resize image.srcset.s}}{{{image.url}}}{{/resize}}" media="(min-width: 490px)">
 	{{/if}}
 	<!--[if IE 9]></video><![endif]-->
 	{{#if image.srcset.fallback}}
-		<img class="n-image__img" src="{{#resize image.srcset.fallback}}{{image.url}}{{/resize}}" alt="{{image.alt}}"/>
+		<img class="n-image__img" src="{{#resize image.srcset.fallback}}{{{image.url}}}{{/resize}}" alt="{{image.alt}}"/>
 	{{else}}
 		{{#if image.srcset.default}}
-			<img class="n-image__img" srcset="{{#resize image.srcset.default}}{{image.url}}{{/resize}}" alt="{{image.alt}}"/>
+			<img class="n-image__img" srcset="{{#resize image.srcset.default}}{{{image.url}}}{{/resize}}" alt="{{image.alt}}"/>
 		{{else}}
 			<img class="n-image__img" alt="{{image.alt}}"/>
 		{{/if}}


### PR DESCRIPTION
The `resize` helper does it already, otherwise you get weird double encoding if the url contains, e.g a `&`

e.g. an image url of

`http://markets.ft.com/Research/API/ChartBuilder?t=indices&p=eyJzeW1ib2wiOiI1OTkxMzkiLCJyZWdpb24iOm51bGwsImhlaWdodCI6IjE5MyIsIndpZHRoIjoiMjcyIiwibGluZVN0eWxlIjoibW91bnRhaW4iLCJkdXJhdGlvbiI6bnVsbCwic3RhcnREYXRlIjo0MjIzNywiZW5kRGF0ZSI6NDIyNDksInByaW1hcnlMYWJlbCI6IkZUU0UgRXVyb2ZpcnN0IDMwMCIsInNlY29uZGFyeUxhYmVsIjoiMjEvMDgvMjAxNSB0byAwMi8wOS8yMDE1IiwidGVydGlhcnlMYWJlbCI6bnVsbCwicXVhdGVybmFyeUxhYmVsIjpudWxsLCJpc01vYmlsZSI6ZmFsc2UsIlNob3dEaXNjbGFpbWVyIjp0cnVlLCJ1bml0IjoicHgifQ==`

outputs something like

`https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fmarkets.ft.com%2FResearch%2FAPI%2FChartBuilder%3Ft%3Dindices%26amp%3Bp%3DeyJzeW1ib2wiOiI1OTkxMzkiLCJyZWdpb24iOm51bGwsImhlaWdodCI6IjE5MyIsIndpZHRoIjoiMjcyIiwibGluZVN0eWxlIjoibW91bnRhaW4iLCJkdXJhdGlvbiI6bnVsbCwic3RhcnREYXRlIjo0MjIzNywiZW5kRGF0ZSI6NDIyNDksInByaW1hcnlMYWJlbCI6IkZUU0UgRXVyb2ZpcnN0IDMwMCIsInNlY29uZGFyeUxhYmVsIjoiMjEvMDgvMjAxNSB0byAwMi8wOS8yMDE1IiwidGVydGlhcnlMYWJlbCI6bnVsbCwicXVhdGVybmFyeUxhYmVsIjpudWxsLCJpc01vYmlsZSI6ZmFsc2UsIlNob3dEaXNjbGFpbWVyIjp0cnVlLCJ1bml0IjoicHgifQ%3D%3D?width=200&source=next&fit=scale-down`

(notice the `%26amp%3B`)