### PR TITLE
Change: srcset from camelcase to lowercase

### DIFF
--- a/templates/image.js
+++ b/templates/image.js
@@ -9,15 +9,15 @@ export default class Image extends Component {
 
 			return 	{__html:
 				`<!--[if IE 9]><video style="display: none;"><![endif]-->
-				${srcset.xl ? `<source srcSet="${addWidth(imageServiceUrl, srcset.xl)}" media="(min-width: 1220px)"/>` : ''}
-				${srcset.l ? `<source srcSet="${addWidth(imageServiceUrl, srcset.l)}" media="(min-width: 980px)"/>` : ''}
-				${srcset.m ? `<source srcSet="${addWidth(imageServiceUrl, srcset.m)}" media="(min-width: 740px)"/>` : ''}
-				${srcset.s ? `<source srcSet="${addWidth(imageServiceUrl, srcset.s)}" media="(min-width: 490px)"/>` : ''}
+				${srcset.xl ? `<source srcset="${addWidth(imageServiceUrl, srcset.xl)}" media="(min-width: 1220px)"/>` : ''}
+				${srcset.l ? `<source srcset="${addWidth(imageServiceUrl, srcset.l)}" media="(min-width: 980px)"/>` : ''}
+				${srcset.m ? `<source srcset="${addWidth(imageServiceUrl, srcset.m)}" media="(min-width: 740px)"/>` : ''}
+				${srcset.s ? `<source srcset="${addWidth(imageServiceUrl, srcset.s)}" media="(min-width: 490px)"/>` : ''}
 				<!--[if IE 9]></video><![endif]-->
 				${srcset.fallback
 					? `<img class="${imgClass}" src="${addWidth(imageServiceUrl, srcset.fallback)}" alt="${alt}"/>`
 					: srcset.default
-						? `<img class="${imgClass}" srcSet="${addWidth(imageServiceUrl, srcset.default)}" alt="${alt}"/>`
+						? `<img class="${imgClass}" srcset="${addWidth(imageServiceUrl, srcset.default)}" alt="${alt}"/>`
 						: `<img class="${imgClass}" alt="${alt}"/>`
 				}`
 			};


### PR DESCRIPTION
cc @ironsidevsquincy 

Given source tags are now rendered as interpolated strings they should use `srcset` (as it should display on the page) rather than `srcSet`, which is required when rendering as a React component.