### PR TITLE
Adds a empty alt attribute when no alt text is set

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -33,9 +33,14 @@ export default class extends Component {
 			.concat(image.classes || [])
 			.join(' ');
 		const attrs = {
-			alt: image.alt,
+			alt: image.alt || '',
 			className
 		};
+
+		if(!attrs.alt) {
+			attrs.role = 'presentation';
+		}
+
 		if (image.src) {
 			Object.assign(attrs, { src: image.src, width: image.width, height: image.height });
 		} else {

--- a/components/picture.js
+++ b/components/picture.js
@@ -28,6 +28,10 @@ const createSources = (urls, { alt = '', classes = [], withFallback = false }) =
 		alt
 	};
 
+	if(!alt) {
+		imgAttrs.role = 'presentation';
+	}
+
 	if (urls.default) {
 		const defaultSrc = urls.default;
 		if (withFallback) {
@@ -60,7 +64,6 @@ export default class extends Component {
 			classes: imgClasses,
 			withFallback: this.props.withFallback
 		};
-
 
 		// dangerouslySetInnerHTML is used to render the conditional IE9 comments
 		// Will throw an error if such comments are returned directly

--- a/tests/templates/image.test.js
+++ b/tests/templates/image.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactTestUtils from 'react-addons-test-utils';
 import chai from 'chai';
 chai.should();
+const expect = chai.expect;
 
 import Image from '../../components/image';
 
@@ -21,6 +22,31 @@ describe('Image', () => {
 	it('should be able to set alt text', () => {
 		const image = <Image url="example/image.jpg" widths={[100]} alt="Description of the image" />;
 		renderComponent(image).props.alt.should.equal('Description of the image');
+	});
+
+	it('should have an empty alt attribute if no alt text set', () => {
+		const image = <Image url="example/image.jpg" widths={[100]} alt="" />;
+		renderComponent(image).props.alt.should.equal('');
+	});
+
+	it('should have an empty alt attribute if no alt attr is set', () => {
+		const image = <Image url="example/image.jpg" widths={[100]} />;
+		renderComponent(image).props.alt.should.equal('');
+	});
+
+	it('should set role to presentation when there is no alt text', () => {
+		const image = <Image url="example/image.jpg" widths={[100]} alt="" />;
+		renderComponent(image).props.role.should.equal('presentation');
+	});
+
+	it('should set role to presentation when there is no alt attr', () => {
+		const image = <Image url="example/image.jpg" widths={[100]} />;
+		renderComponent(image).props.role.should.equal('presentation');
+	});
+
+	it('should NOT set role to presentation when there is alt text', () => {
+		const image = <Image url="example/image.jpg" widths={[100]} alt="Description of the image" />;
+		expect(renderComponent(image).props.role).to.not.exist;
 	});
 
 	it('should be able to set classes', () => {

--- a/tests/templates/picture.test.js
+++ b/tests/templates/picture.test.js
@@ -13,7 +13,7 @@ const renderComponent = element => {
 
 const getInnerHTML = element => element.props.dangerouslySetInnerHTML.__html;
 
-describe('Image', () => {
+describe('Picture', () => {
 
 	it('should be able to create', () => {
 		const picture = <Picture urls={{ default: 'an/image.jpg' }} />;
@@ -22,7 +22,7 @@ describe('Image', () => {
 
 	it('should be able to set default image', () => {
 		const picture = <Picture urls={{ default: 'an/image.jpg' }} />;
-		getInnerHTML(renderComponent(picture)).should.equal('<img class="n-image__img" alt="" srcset="an/image.jpg" />');
+		getInnerHTML(renderComponent(picture)).should.equal('<img class="n-image__img" alt="" role="presentation" srcset="an/image.jpg" />');
 	});
 
 	it('should be able to not supply default image', () => {
@@ -31,7 +31,7 @@ describe('Image', () => {
 			'<!--[if IE 9]><video style="display: none;"><![endif]-->' +
 			'<source srcset="another/image.jpg" media="(min-width: 740px)" />' +
 			'<!--[if IE 9]></video><![endif]-->' +
-			'<img class="n-image__img" alt="" />'
+			'<img class="n-image__img" alt="" role="presentation" />'
 		);
 	});
 
@@ -45,7 +45,7 @@ describe('Image', () => {
 
 	it('should be able to set fallback image', () => {
 		const picture = <Picture urls={{ default: 'an/image.jpg' }} withFallback={true} />;
-		getInnerHTML(renderComponent(picture)).should.equal('<img class="n-image__img" alt="" src="an/image.jpg" />');
+		getInnerHTML(renderComponent(picture)).should.equal('<img class="n-image__img" alt="" role="presentation" src="an/image.jpg" />');
 	});
 
 	it('should be able to set classes', () => {
@@ -55,12 +55,37 @@ describe('Image', () => {
 
 	it('should be able to set alt', () => {
 		const picture = <Picture urls={{ default: 'an/image.jpg' }} alt="A useful description" />;
-		getInnerHTML(renderComponent(picture)).should.equal('<img class="n-image__img" alt="A useful description" srcset="an/image.jpg" />');
+		getInnerHTML(renderComponent(picture)).should.contain('alt="A useful description"');
+	});
+
+	it('should have an empty alt attribute if no alt text set', () => {
+		const picture = <Picture urls={{ default: 'an/image.jpg' }} alt="" />;
+		getInnerHTML(renderComponent(picture)).should.contain('alt=""');
+	});
+
+	it('should have an empty alt attribute if no alt attr is set', () => {
+		const picture = <Picture urls={{ default: 'an/image.jpg' }} />;
+		getInnerHTML(renderComponent(picture)).should.contain('alt=""');
+	});
+
+	it('should set role to presentation when there is no alt text', () => {
+		const picture = <Picture urls={{ default: 'an/image.jpg' }} alt="" />;
+		getInnerHTML(renderComponent(picture)).should.contain('role="presentation"');
+	});
+
+	it('should set role to presentation when there is no alt attr', () => {
+		const picture = <Picture urls={{ default: 'an/image.jpg' }} />;
+		getInnerHTML(renderComponent(picture)).should.contain('role="presentation"');
+	});
+
+	it('should NOT set role to presentation when there is alt text', () => {
+		const picture = <Picture urls={{ default: 'an/image.jpg' }} alt="Decription of the image" />;
+		getInnerHTML(renderComponent(picture)).should.not.contain('role="presentation"');
 	});
 
 	it('should be able to set img classes', () => {
 		const picture = <Picture urls={{ default: 'an/image.jpg' }} imgClasses={['a-class', 'another-class']} />;
-		getInnerHTML(renderComponent(picture)).should.equal('<img class="n-image__img a-class another-class" alt="" srcset="an/image.jpg" />');
+		getInnerHTML(renderComponent(picture)).should.contain('class="n-image__img a-class another-class"');
 	});
 
 });


### PR DESCRIPTION
Allows for either no alt attr or `alt=""`
Also adds `role="presentation"` when the alt is empty