### PR TITLE
Let the host domain be configurable

### DIFF
--- a/src/helpers/build-image-service-url.js
+++ b/src/helpers/build-image-service-url.js
@@ -1,6 +1,6 @@
 import qs from 'querystring';
 
-export default (url, params = {}, host = 'https://next-geebee.ft.com/image/v1/images/raw/') => {
+export default (url, params = {}, { host = 'https://next-geebee.ft.com/image/v1/images/raw/' } = { }) => {
 	const defaultOptions = {
 		source: 'next',
 		fit: 'scale-down',

--- a/src/helpers/build-image-service-url.js
+++ b/src/helpers/build-image-service-url.js
@@ -1,12 +1,11 @@
 import qs from 'querystring';
 
-export default (url, params = {}) => {
+export default (url, params = {}, host = 'https://next-geebee.ft.com/image/v1/images/raw/') => {
 	const defaultOptions = {
 		source: 'next',
 		fit: 'scale-down',
 		compression: 'best'
 	};
 	const options = Object.assign({}, defaultOptions, params);
-
-	return `https://next-geebee.ft.com/image/v1/images/raw/${encodeURIComponent(url)}?${qs.stringify(options)}`;
+	return `${host + encodeURIComponent(url)}?${qs.stringify(options)}`;
 };


### PR DESCRIPTION
### Problem
Currently there is no way to change where images are be served from. We are wanting to serve images from `https://www.ft.com/origami/service/image` for the new version of the image service and would like to test this behind a flag.

### Solution
Enable the host of the image url to be configurable (with a default on the current image service), thereby allowing applications to change to the new image service when they see the flag is set.