### PR TITLE
Pass custom `source` param to the image service

### DIFF
--- a/src/presenters/image.js
+++ b/src/presenters/image.js
@@ -19,7 +19,7 @@ const createImageSizes = require('../helpers/create-image-sizes');
  * @param {string} [height] - Height of the image
  * @param {string} [alt = ''] - Alt text for the image
  * @param {boolean} [lazyLoad = false] - Lazy load the image
- * @param {string} [sourceParam = 'next] - The `source` parameter used in the image service request
+ * @param {string} [sourceParam = 'next'] - The `source` parameter used in the image service request
  * @param {string|number} [placeholder] - Set to add a placeholder. Value should be the ratio of the image as a number
  * (width divided by height, e.g.`16/9`), or string (`square` or `landscape`)
  */

--- a/src/presenters/image.js
+++ b/src/presenters/image.js
@@ -19,6 +19,7 @@ const createImageSizes = require('../helpers/create-image-sizes');
  * @param {string} [height] - Height of the image
  * @param {string} [alt = ''] - Alt text for the image
  * @param {boolean} [lazyLoad = false] - Lazy load the image
+ * @param {string} [sourceParam = 'next] - The `source` parameter used in the image service request
  * @param {string|number} [placeholder] - Set to add a placeholder. Value should be the ratio of the image as a number
  * (width divided by height, e.g.`16/9`), or string (`square` or `landscape`)
  */
@@ -127,6 +128,7 @@ class ImagePresenter {
 		const sizes = this.convertToJson(this.data.sizes) || this.imageSizes() || {};
 		const widths = this.convertToJson(this.data.widths) || [];
 		const srcSet = this.data.srcSet || this.data.url;
+		const sourceParam = this.data.sourceParam || 'next';
 
 		if (!this.data.src && !srcSet) {
 			console.warn('No source for image provided');
@@ -138,7 +140,7 @@ class ImagePresenter {
 			}
 			sourceAttrs.srcSet = widths
 				.sort((widthOne, widthTwo) => widthTwo - widthOne)
-				.map(width => `${buildImageServiceUrl(srcSet, { width })} ${width}w`)
+				.map(width => `${buildImageServiceUrl(srcSet, { width, source: sourceParam })} ${width}w`)
 				.join(', ');
 
 			sourceAttrs.sizes = breakpoints

--- a/tests/presenters/image.test.js
+++ b/tests/presenters/image.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import ImagePresenter from '../../src/presenters/image';
+import url from 'url';
 
 describe('Image Presenter', () => {
 	describe('Placeholders', () => {
@@ -169,6 +170,17 @@ describe('Image Presenter', () => {
 			});
 			expect(inst.imgAttrs.srcSet).to.not.be.defined;
 			expect(inst.imgAttrs['data-srcset']).to.equal('https://www.ft.com/__origami/service/image/v2/images/raw/foo.jpg?source=next&fit=scale-down&compression=best&width=200 200w, https://www.ft.com/__origami/service/image/v2/images/raw/foo.jpg?source=next&fit=scale-down&compression=best&width=100 100w');
+		});
+
+		it('allows a custom `source` parameter to be set for image service requests', () => {
+			const inst = new ImagePresenter({
+				srcSet: 'foo.jpg',
+				widths: '[100]',
+				lazyLoad: true,
+				sourceParam: 'custom'
+			});
+			const imageUrl = url.parse(inst.imgAttrs['data-srcset'], true);
+			expect(imageUrl.query.source).to.equal('custom');
 		});
 	});
 });


### PR DESCRIPTION
**Rationale:**
Soon, all n-* components (that have at least 1 template) will have a demo server, which in turn will be used to run pa11y tests.
For demo templates with images, it’d help the Origami folks out if we could use a different [`source` parameter for image service requests](https://www.ft.com/__origami/service/image/v2/docs/api), so that they can identify traffic coming from any given component. This PR allows that.

@lc512k @laurieboyes 