### PR TITLE
Don't send image service URLs to the image service again

### DIFF
--- a/src/helpers/build-image-service-url.js
+++ b/src/helpers/build-image-service-url.js
@@ -3,6 +3,11 @@ const qs = require('querystring');
 const capiRX = /^https?:\/\/(?:com\.ft\.imagepublish\.prod(?:-us)?\.s3\.amazonaws\.com|im\.ft-static\.com\/content\/images)\/([0-9a-f-]+)(?:\.img)?$/i
 
 module.exports = (url, params = {}, { host = 'https://www.ft.com/__origami/service/image/v2/images/raw/' } = { }) => {
+	//if the url is already an image service URL, serve it as is
+	if(url.includes(host)) {
+		return url;
+	}
+
 	const defaultOptions = {
 		source: 'next',
 		fit: 'scale-down',

--- a/tests/helpers/build-image-service-urls.test.js
+++ b/tests/helpers/build-image-service-urls.test.js
@@ -16,4 +16,10 @@ describe('Build image service url helper', () => {
 		const imageUrl = buildImageServiceUrl('https://www.example.com/image.png');
 		expect(imageUrl).to.equal('https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.example.com%2Fimage.png?source=next&fit=scale-down&compression=best');
 	});
+
+	it('does not send image service urls to the image service again', () => {
+		const imageUrl = buildImageServiceUrl('https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1:tim-harford?source=next&fit=scale-down&compression=best&tint=054593,d6d5d3');
+		expect(imageUrl).to.equal('https://www.ft.com/__origami/service/image/v2/images/raw/fthead-v1:tim-harford?source=next&fit=scale-down&compression=best&tint=054593,d6d5d3');
+	});
+
 });


### PR DESCRIPTION
Currently our headshots on teasers are being constructed as image service URLs, and therefore are being sent to the image service twice - which makes hard for images to be purged (and also probably slower when not cached?)