### PR TITLE
fix(placeholder): respect loaded img aspect ratio

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -56,9 +56,7 @@ $_n-image_applied: false !default;
 		transition: opacity 1s;
 
 		.n-image-wrapper--placeholder & {
-			position: absolute;
-			top: 0;
-			left: 0;
+			float: left;
 			min-height: 1px; //Edge IntersectionObserver requires a non-zero height and width
 		}
 	}


### PR DESCRIPTION
Fixes https://jira.ft.com/browse/NFT-849 - image overlap on lazy loading, e.g. https://www.ft.com/stream/89d15f70-640d-11e4-9803-0800200c9a66

I already implemented and released this fix on `o-teaser`: https://github.com/Financial-Times/o-teaser/releases/tag/v2.0.1