### PR TITLE
Lazy loading enhancements

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -55,7 +55,10 @@ $_n-image_applied: false !default;
 		display: block;
 		max-width: 100%;
 		opacity: 1;
-		transition: opacity 1s;
+
+		&.n-image--fade-on-load {
+			transition: opacity 1s;
+		}
 
 		.n-image-wrapper--placeholder & {
 			float: left;

--- a/main.scss
+++ b/main.scss
@@ -57,7 +57,7 @@ $_n-image_applied: false !default;
 		opacity: 1;
 
 		&.n-image--fade-on-load {
-			transition: opacity 1s;
+			transition: opacity 0.5s;
 		}
 
 		.n-image-wrapper--placeholder & {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "chalk": "^1.1.3",
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^5.0.1",
+    "jsdom": "^11.6.2",
     "lintspaces-cli": "^0.4.0",
     "mocha": "^2.4.5",
     "node-sass": "^4.1.1",
     "npm-prepublish": "^1.2.1",
-    "pa11y-ci": "^1.1.1"
+    "pa11y-ci": "^1.1.1",
+    "sinon": "^4.4.2"
   },
   "dependencies": {
     "@financial-times/n-logger": "^5.4.0"

--- a/src/lib/browserFeatureDetect.js
+++ b/src/lib/browserFeatureDetect.js
@@ -1,0 +1,20 @@
+module.exports = {
+	eventListenOptionSupported: (option) => {
+		let supported = false;
+
+		try {
+			const options = Object.defineProperty({}, option, {
+				get: () => {
+					supported = true;
+				}
+			});
+
+			window.addEventListener('test', options, options);
+			window.removeEventListener('test', options, options);
+		} catch (err) {
+			supported = false;
+		}
+
+		return supported;
+	}
+};

--- a/src/lib/lazy-load.js
+++ b/src/lib/lazy-load.js
@@ -73,13 +73,9 @@ const imageHasLoaded = img => {
 
 const loadImage = img => {
 	const uid = setUid(img);
-	const start = Date.now();
-	
 	img.addEventListener('load', () => {
 		// NOTE: rather arbitrary, needed to get the fading to always work (possibly classes being removed to quickly)
 		setTimeout(imageHasLoaded.bind(null, img), 13);
-		const end = Date.now();
-		console.log(`Loading took ${end - start}ms`);
 	});
 	mark('START', uid);
 	// add the src/srcset attribtues back in
@@ -118,10 +114,14 @@ const observeIntersection = ({ observer }, img) => {
  * @param {Element} [opts.root = document] - Where in the DOM to search for images
  */
 module.exports = ({ root = document } = { }) => {
+	const verticalMargin = window.FT && window.FT.flags && window.FT.flags.get('imgLazyLoadThreshold') || '0px';
 	const observer = window.IntersectionObserver ?
 		new window.IntersectionObserver(
 			function (changes) {
 				intersectionCallback(this, changes);
+			},
+			{
+				rootMargin: `${verticalMargin} 0px ${verticalMargin} 0px`
 			}
 		) :
 		null;

--- a/src/lib/lazy-load.js
+++ b/src/lib/lazy-load.js
@@ -73,9 +73,13 @@ const imageHasLoaded = img => {
 
 const loadImage = img => {
 	const uid = setUid(img);
+	const start = Date.now();
+	
 	img.addEventListener('load', () => {
 		// NOTE: rather arbitrary, needed to get the fading to always work (possibly classes being removed to quickly)
 		setTimeout(imageHasLoaded.bind(null, img), 13);
+		const end = Date.now();
+		console.log(`Loading took ${end - start}ms`);
 	});
 	mark('START', uid);
 	// add the src/srcset attribtues back in
@@ -115,7 +119,7 @@ const observeIntersection = ({ observer }, img) => {
  */
 module.exports = ({ root = document } = { }) => {
 	const observer = window.IntersectionObserver ?
-		new IntersectionObserver(
+		new window.IntersectionObserver(
 			function (changes) {
 				intersectionCallback(this, changes);
 			}

--- a/src/lib/lazy-load.js
+++ b/src/lib/lazy-load.js
@@ -1,9 +1,11 @@
+const featureDetect = require('./browserFeatureDetect');
 const lazyLoadingModifier = 'lazy-loading';
 const lazyLoadingImageClass = `n-image--${lazyLoadingModifier}`;
 const lazyLoadingWrapperClass = `n-image-wrapper--${lazyLoadingModifier}`;
 
 const uid = () => (Date.now() * Math.random()).toString(16);
 const performance = window.LUX || window.performance || window.msPerformance || window.webkitPerformance || window.mozPerformance;
+const eventListenOnceSupported = featureDetect.eventListenOptionSupported('once');
 
 //todo this stuff all lives (or should live) in n-ui but circular dependencies don't work
 const perfMeasure = (name, start, end) => {
@@ -67,7 +69,6 @@ const imageHasLoaded = img => {
 	measure(uid);
 	img.classList.remove(lazyLoadingImageClass);
 	img.parentNode.classList.remove(lazyLoadingWrapperClass);
-	img.removeEventListener('load', imageHasLoaded);
 	report(uid);
 };
 
@@ -76,9 +77,9 @@ const loadImage = img => {
 	img.addEventListener('load', () => {
 		// NOTE: rather arbitrary, needed to get the fading to always work (possibly classes being removed to quickly)
 		setTimeout(imageHasLoaded.bind(null, img), 13);
-	});
+	}, eventListenOnceSupported ? { once: true } : undefined);
 	mark('START', uid);
-	// add the src/srcset attribtues back in
+	// add the src/srcset attributes back in
 	[...img.attributes]
 		.forEach(attr => {
 			if (/^data-src(set)?$/.test(attr.name)) {

--- a/templates/image.html
+++ b/templates/image.html
@@ -11,6 +11,8 @@
 		{{#if data-srcset}} data-srcset="{{data-srcset}}"{{/if}}
 		{{#if sizes}} sizes="{{sizes}}"{{/if}}
 		{{#if role}} role="{{role}}"{{/if}}
-		alt="{{alt}}" class="{{className}}" />
+		alt="{{alt}}"
+		class="{{className}}{{#unless @root.flags.imgNoFadeOnLoad}} n-image--fade-on-load{{/unless}}"
+		/>
 	{{/with}}
 </div>

--- a/tests/lib/lazy-load.test.js
+++ b/tests/lib/lazy-load.test.js
@@ -1,58 +1,100 @@
-const { expect } = require('chai');
-const { JSDOM } = require('jsdom');
+const {expect} = require('chai');
+const {JSDOM} = require('jsdom');
 const sinon = require('sinon');
 
 describe('lazy-load', () => {
-  let dom;
-  let lazyLoad;
-  let MockIntersectionObserver;
-  let MockIntersectionObserverConstructorSpy;
-  let MockIntersectionObserverObserveSpy;
-  
-  beforeEach(() => {
-    dom = new JSDOM(`
-      <img id="image1" class="n-image--lazy-loading" />
-      <img id="image2" class="n-image--lazy-loading" />
-      <img id="image3" class="not-lazy-loading" />
-    `);
-    
-    global.window = dom.window;
-    global.document = dom.window.document;
-  });
-  
-  describe('given window.IntersectionObserver is supported', () => {
-    beforeEach(() => {
-      MockIntersectionObserverConstructorSpy = sinon.spy();
-      MockIntersectionObserverObserveSpy = sinon.spy();
-      MockIntersectionObserver = class IntersectionObserver {
-        constructor(callback, options) {
-          MockIntersectionObserverConstructorSpy(callback, options);
-        }
+	let dom;
+	let lazyLoad;
+	let MockIntersectionObserver;
+	let MockIntersectionObserverConstructorSpy;
+	let MockIntersectionObserverObserveSpy;
+	let mockFlags;
 
-        observe(el) {
-          MockIntersectionObserverObserveSpy(el);
-        }
-      };
+	beforeEach(() => {
+		mockFlags = {};
+		dom = new JSDOM(`
+		<img id="image1" class="n-image--lazy-loading" />
+		<img id="image2" class="n-image--lazy-loading" />
+		<img id="image3" class="not-lazy-loading" />
+	`);
 
-      global.window.IntersectionObserver = MockIntersectionObserver;
-      lazyLoad = require('../../src/lib/lazy-load');
+		global.window = dom.window;
+		global.document = dom.window.document;
 
-      lazyLoad();
-    });
+		global.window.FT = {
+			flags: {
+				get: flag => mockFlags[flag]
+			}
+		};
+	});
 
-    it('should construct an IntersectionObserver', () => {
-      expect(MockIntersectionObserverConstructorSpy.callCount).to.equal(1);
-      
-      const constructorArgs = MockIntersectionObserverConstructorSpy.args[0];
-      
-      expect(typeof constructorArgs[0]).to.equal('function');
-    });
-    
-    it('should observe each image with the lazy-loading class', () => {
-      expect(MockIntersectionObserverObserveSpy.callCount).to.equal(2);
-      expect(MockIntersectionObserverObserveSpy.args[0][0].id).to.equal('image1');
-      expect(MockIntersectionObserverObserveSpy.args[1][0].id).to.equal('image2');
-    });
-  });
-  
+	describe('construction', () => {
+		describe('given window.IntersectionObserver is supported', () => {
+			beforeEach(() => {
+				MockIntersectionObserverConstructorSpy = sinon.spy();
+				MockIntersectionObserverObserveSpy = sinon.spy();
+				MockIntersectionObserver = class IntersectionObserver {
+					constructor (callback, options) {
+						MockIntersectionObserverConstructorSpy(callback, options);
+					}
+
+					observe (el) {
+						MockIntersectionObserverObserveSpy(el);
+					}
+				};
+
+				global.window.IntersectionObserver = MockIntersectionObserver;
+				lazyLoad = require('../../src/lib/lazy-load');
+			});
+
+			describe('and no imgLazyLoadThreshold flag is set', () => {
+				beforeEach(() => {
+					lazyLoad();
+				});
+
+				it('should construct an IntersectionObserver with 0px rootMargin', () => {
+					expect(MockIntersectionObserverConstructorSpy.callCount).to.equal(1);
+
+					const constructorArgs = MockIntersectionObserverConstructorSpy.args[0];
+
+					expect(typeof constructorArgs[0]).to.equal('function');
+					expect(constructorArgs[1]).to.eql({
+						rootMargin: '0px 0px 0px 0px'
+					});
+				});
+			});
+
+			describe('and a imgLazyLoadThreshold flag is set', () => {
+				const THRESHOLD = '100px';
+				beforeEach(() => {
+					mockFlags['imgLazyLoadThreshold'] = THRESHOLD;
+					lazyLoad();
+				});
+
+				it('should construct an IntersectionObserver with the rootMargin from the flag', () => {
+					expect(MockIntersectionObserverConstructorSpy.callCount).to.equal(1);
+
+					const constructorArgs = MockIntersectionObserverConstructorSpy.args[0];
+
+					expect(typeof constructorArgs[0]).to.equal('function');
+					expect(constructorArgs[1]).to.eql({
+						rootMargin: `${THRESHOLD} 0px ${THRESHOLD} 0px`
+					});
+				});
+			});
+		});
+
+		describe('observing images', () => {
+			beforeEach(() => {
+				lazyLoad();
+			});
+
+			it('should observe each image with the lazy-loading class', () => {
+				expect(MockIntersectionObserverObserveSpy.callCount).to.equal(2);
+				expect(MockIntersectionObserverObserveSpy.args[0][0].id).to.equal('image1');
+				expect(MockIntersectionObserverObserveSpy.args[1][0].id).to.equal('image2');
+			});
+		});
+	});
+
 });

--- a/tests/lib/lazy-load.test.js
+++ b/tests/lib/lazy-load.test.js
@@ -1,0 +1,58 @@
+const { expect } = require('chai');
+const { JSDOM } = require('jsdom');
+const sinon = require('sinon');
+
+describe('lazy-load', () => {
+  let dom;
+  let lazyLoad;
+  let MockIntersectionObserver;
+  let MockIntersectionObserverConstructorSpy;
+  let MockIntersectionObserverObserveSpy;
+  
+  beforeEach(() => {
+    dom = new JSDOM(`
+      <img id="image1" class="n-image--lazy-loading" />
+      <img id="image2" class="n-image--lazy-loading" />
+      <img id="image3" class="not-lazy-loading" />
+    `);
+    
+    global.window = dom.window;
+    global.document = dom.window.document;
+  });
+  
+  describe('given window.IntersectionObserver is supported', () => {
+    beforeEach(() => {
+      MockIntersectionObserverConstructorSpy = sinon.spy();
+      MockIntersectionObserverObserveSpy = sinon.spy();
+      MockIntersectionObserver = class IntersectionObserver {
+        constructor(callback, options) {
+          MockIntersectionObserverConstructorSpy(callback, options);
+        }
+
+        observe(el) {
+          MockIntersectionObserverObserveSpy(el);
+        }
+      };
+
+      global.window.IntersectionObserver = MockIntersectionObserver;
+      lazyLoad = require('../../src/lib/lazy-load');
+
+      lazyLoad();
+    });
+
+    it('should construct an IntersectionObserver', () => {
+      expect(MockIntersectionObserverConstructorSpy.callCount).to.equal(1);
+      
+      const constructorArgs = MockIntersectionObserverConstructorSpy.args[0];
+      
+      expect(typeof constructorArgs[0]).to.equal('function');
+    });
+    
+    it('should observe each image with the lazy-loading class', () => {
+      expect(MockIntersectionObserverObserveSpy.callCount).to.equal(2);
+      expect(MockIntersectionObserverObserveSpy.args[0][0].id).to.equal('image1');
+      expect(MockIntersectionObserverObserveSpy.args[1][0].id).to.equal('image2');
+    });
+  });
+  
+});


### PR DESCRIPTION
To counter occasional long TTFB times when requesting lazy-loaded images, and increase the perceived speed of image loading, do the following:

* [x] Allow images to be lazy-loaded when they are scrolled within x pixels of the viewport (rather than just when they actually enter the viewport). This is controlled with the `imgLazyLoadThreshold` flag.
* [x] Remove the 1-second fade transition once the image has loaded (just show it instantly) - this is controlled with the `imgNoFadeOnLoad` flag.

Bonus fix:
* `removeEventListener` for the img `load` event wasn't working - as the function passed in wasn't the function listened for. I've removed this in favour of using the `addEventListener` `once` option, where it is supported.